### PR TITLE
Simplify nvidia-smi collection a bit

### DIFF
--- a/src/collector/nvidia_collector.py
+++ b/src/collector/nvidia_collector.py
@@ -103,7 +103,7 @@ class SMIOverTimeTestRun():
         self.units = units
 
         measurements_string = ",".join(self.measurements)
-        self.smi_runstring = "nvidia-smi --query-gpu=timestamp,index,{measure} --loop-ms=1000 --format=csv"
+        self.smi_runstring = "nvidia-smi --query-gpu=timestamp,index,{measure} --loop-ms=1000 --format=csv,noheader,nounits"
         self.smi_runcommand = self.smi_runstring.format(filename = self.filename, measure = measurements_string)
         self.bench_runcommand = self.benchmark.get_run_command()
         self.data = {   "benchmark_name":   self.benchmark.name, \
@@ -132,7 +132,6 @@ class SMIOverTimeTestRun():
         # Collect data
         gpu_indices = set()
         with open(smi_filename, 'r') as csvfile:
-            next(csvfile)
             for line in csvfile:
                 line = line.strip().split(",")
                 if len(line) > 1:
@@ -141,7 +140,7 @@ class SMIOverTimeTestRun():
                     gpu_indices.add(gpu_index)
                     for i, measurement in enumerate(self.measurements):
                         key = "gpu_{index}_{measurement}".format(index = gpu_index, measurement = measurement)
-                        self.data.setdefault(key, []).append((time, float(line[i+2].split()[0].strip())))
+                        self.data.setdefault(key, []).append((time, float(line[i+2].strip())))
 
         # Clean up files
         os.remove(smi_filename)


### PR DESCRIPTION
Output should be identical, but I haven't tested this.

---

AFAICT the docs don't explicitly guarantee that the output column order will match the order supplied to `query-gpu`, but it would be weird to offer `noheader` otherwise.

---

It may be necessary to manually insert empty columns in some collectors, but in this case
- we're already assuming that if we get even one line for a given GPU it includes all our measurements, and
- we must get at least one line for each GPU for it to be saved in `gpu_indices` anyway,

so it's safe to fill them in as they're encountered.

---

Is there a particular reason to expect lines of less than two fields? (Or is that check just to prevent crashes? Because it doesn't, if the field count is greater than `2` but less than `len(measurements)+2`. Also, if so, should probably emit a warning once we get logging fixed.)